### PR TITLE
✅ 9 - CI Test Script

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test",
+    "test": "CI=true react-scripts test",
+    "test-dev": "react-scripts test",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {


### PR DESCRIPTION
Modify the test script to set an environment variable `CI` to `true`, so that when you test in publishing and CI, the test runner only runs once instead of hanging.

Also added a `test-dev` script to run the watcher as expected.